### PR TITLE
Improve fast_fifo

### DIFF
--- a/src/fast_fifo.ml
+++ b/src/fast_fifo.ml
@@ -63,7 +63,7 @@ module Make (M : Hardcaml.Interface.S) = struct
     let rd_valid =
       if cut_through
       then ~:(i.clear) &: (~:(underlying_fifo.empty) |: i.wr_enable)
-      else ~:(i.clear) &: ~:(underlying_fifo.empty)
+      else ~:(underlying_fifo.empty)
     in
     { O.full = underlying_fifo.full
     ; rd_data


### PR DESCRIPTION
- Fix bug preventing writes when reading empty fifo
- Pass scope through to underlying fifo
- Support naming the fast_fifo
- Remove unnecessary checks